### PR TITLE
Add option to provide socket timeout at the time of building connection

### DIFF
--- a/lib/Net/AMQP/RabbitMQ/PP.pm
+++ b/lib/Net/AMQP/RabbitMQ/PP.pm
@@ -62,6 +62,7 @@ sub connect {
 				PeerAddr => $args{host} || 'localhost',
 				PeerPort => $args{port} || ( $args{secure} ? 5671 : 5672 ),
 				( ! $args{secure} ? ( Proto => 'tcp' ) : () ),
+				( $args{socket_timeout} ? ( Timeout => $args{socket_timeout} ) : () ),
 			) or Carp::croak "Could not connect: $EVAL_ERROR"
 		);
 
@@ -944,13 +945,14 @@ connection until ->connect is called.
 Connect to the server. Default arguments are show below:
 
 	$mq->connect(
-		host        => "localhost",
-		port        => 5672,
-		timeout     => undef,
-		username    => 'guest',
-		password    => 'guest',
-		virtualhost => '/',
-		heartbeat   => undef,
+		host           => "localhost",
+		port           => 5672,
+		timeout        => undef,
+		username       => 'guest',
+		password       => 'guest',
+		virtualhost    => '/',
+		heartbeat      => undef,
+		socket_timeout => 5,
 	);
 
 connect can also take a secure flag for SSL connections, this will only work if


### PR DESCRIPTION
As specified here https://metacpan.org/pod/IO::Socket::INET we should be able to provide Timeout value when building a socket.
If, for an example, we lose a connection to server previous operation will stall for long period if not timeout value has been given. If a connection could not be established and the given timeout value has been reached an exception will be thrown e.g.
```
Could not connect to RabbitMQ: Could not connect: IO::Socket::INET: connect: timeout at net-amqp-rabbitmq-master/lib/Net/AMQP/RabbitMQ/PP.pm line 80.
```